### PR TITLE
Fix code scanning alert no. 1: Missing function level access control

### DIFF
--- a/MyDotnetAPI/Controllers/AdminController.cs
+++ b/MyDotnetAPI/Controllers/AdminController.cs
@@ -6,7 +6,7 @@ namespace MyDotnetAPI.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-//[Authorize]
+[Authorize]
 public class AdminController : ControllerBase
 {
     [HttpGet]


### PR DESCRIPTION
Fixes [https://github.com/jrtm/MyDotnetProject/security/code-scanning/1](https://github.com/jrtm/MyDotnetProject/security/code-scanning/1)

To fix the problem, we need to ensure that only authorized users can access the `Get` and `Post` methods in the `AdminController` class. The best way to achieve this in an ASP.NET Core MVC application is to use the `[Authorize]` attribute, which restricts access to authenticated users. Additionally, we can specify roles if needed to further restrict access to users with specific roles.

1. Add the `[Authorize]` attribute to the `AdminController` class to ensure that all actions within the controller require authorization.
2. If specific roles are required, modify the `[Authorize]` attribute to include role-based authorization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
